### PR TITLE
disable certificate validation

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -173,7 +173,8 @@ class App < Sinatra::Base
               :user_name            => ENV['AUTH_EMAIL'],
               :password             => ENV['AUTH_EMAIL_PASSWORD'],
               :authentication       => 'plain',
-              :enable_starttls_auto => true  }
+              :enable_starttls_auto => true,
+              :openssl_verify_mode  => 'none'}
   Mail.defaults do
     delivery_method :smtp, options
   end


### PR DESCRIPTION
Fix TLS enabled but there is no valid certificate.

```
/openssl/ssl.rb:315:in `post_connection_check': hostname "example.com" does not match the server certificate (OpenSSL::SSL::SSLError)
	from /home/user/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/net/smtp.rb:589:in `tlsconnect'
	from /home/user/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/net/smtp.rb:564:in `do_start'
	from /home/user/.rvm/rubies/ruby-2.3.0/lib/ruby/2.3.0/net/smtp.rb:521:in `start'
	from /home/user/.rvm/gems/ruby-2.4.0/gems/mail-2.6.6/lib/mail/network/delivery_methods/smtp.rb:111:in `deliver!'
	from /home/user/.rvm/gems/ruby-2.4.0/gems/mail-2.6.6/lib/mail/message.rb:2149:in `do_delivery'
	from /home/user/.rvm/gems/ruby-2.4.0/gems/mail-2.6.6/lib/mail/message.rb:239:in `deliver'
	from /home/user/.rvm/gems/ruby-2.4.0/gems/mail-2.6.6/lib/mail/mail.rb:141:in `deliver'
```